### PR TITLE
Bump version, because README.md was lost on publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-natives",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A library used by TestCafe for performing platform-dependent actions on browsers.",
   "homepage": "https://github.com/DevExpress/testcafe-browser-natives",
   "bugs": "https://github.com/DevExpress/testcafe-browser-natives/issues",


### PR DESCRIPTION
node>6.0.0 + npm<3.10.1 = lost README.md on publishing
https://github.com/npm/npm/releases/tag/v3.10.1